### PR TITLE
Fix : remove precision, scale from Entity

### DIFF
--- a/src/main/java/com/test/feelio/entity/ActivityEffect.java
+++ b/src/main/java/com/test/feelio/entity/ActivityEffect.java
@@ -28,7 +28,7 @@ public class ActivityEffect {
     @Column(name = "ACTIVITY_NAME", nullable = false, length = 100)
     private String activityName;
 
-    @Column(name = "AVERAGE_CHANGE_SCORE", precision = 3, scale = 2)
+    @Column(name = "AVERAGE_CHANGE_SCORE")
     private Double averageChangeScore;
 
     @Column(name = "USAGE_COUNT")

--- a/src/main/java/com/test/feelio/entity/DiaryActivity.java
+++ b/src/main/java/com/test/feelio/entity/DiaryActivity.java
@@ -28,7 +28,7 @@ public class DiaryActivity {
     @Column(name = "ACTIVITY_NAME", nullable = false, length = 100)
     private String activityName;
 
-    @Column(name = "ACTIVITY_SENTIMENT", precision = 3, scale = 2)
+    @Column(name = "ACTIVITY_SENTIMENT")
     private Double activitySentiment;
 
     @Column(name = "CREATED_AT", nullable = false, updatable = false)

--- a/src/main/java/com/test/feelio/entity/DiaryEmotion.java
+++ b/src/main/java/com/test/feelio/entity/DiaryEmotion.java
@@ -29,7 +29,7 @@ public class DiaryEmotion {
     @JoinColumn(name = "EMOTION_ID", nullable = false)
     private Emotion emotion;
 
-    @Column(name = "EMOTION_PERCENTAGE", nullable = false, precision = 5, scale = 2)
+    @Column(name = "EMOTION_PERCENTAGE", nullable = false)
     private Double emotionPercentage;
 
     @Column(name = "IS_PRIMARY_EMOTION")

--- a/src/main/java/com/test/feelio/entity/UserActivityRecord.java
+++ b/src/main/java/com/test/feelio/entity/UserActivityRecord.java
@@ -37,7 +37,7 @@ public class UserActivityRecord {
     @JoinColumn(name = "EMOTION_AFTER_ID")
     private Emotion emotionAfter;
 
-    @Column(name = "EMOTION_CHANGE_SCORE", precision = 3, scale = 2)
+    @Column(name = "EMOTION_CHANGE_SCORE")
     private Double emotionChangeScore;
 
     @Column(name = "ACTIVITY_DATE")

--- a/src/main/java/com/test/feelio/entity/UserEmotionScore.java
+++ b/src/main/java/com/test/feelio/entity/UserEmotionScore.java
@@ -30,7 +30,7 @@ public class UserEmotionScore {
     @JoinColumn(name = "EMOTION_ID", nullable = false)
     private Emotion emotion;
 
-    @Column(nullable = false, precision = 5, scale = 2)
+    @Column(nullable = false)
     private Double score;
 
     @Column(name = "SCORE_DATE", nullable = false)


### PR DESCRIPTION
### Entity 관련 에러
`@Column` 어노테이션에서 `scale` 속성을 지정할 수 없어서 발생한 에러 해결
Hibernate는 부동 소수점 타입(`float`, `double`)에 `scale` 속성을 사용할 수 없다고 합니다.
